### PR TITLE
fix qr_display_thread not being initialized with otp

### DIFF
--- a/BrowserClient/BrowserClient.py
+++ b/BrowserClient/BrowserClient.py
@@ -278,6 +278,7 @@ class BrowserClient():
         ticket = r["ticket"]
         print("Login request has been made, open your MitID app now")
         qr_stop_event = None
+        qr_display_thread = None
         while True:
             r = self.session.post(poll_url, json={"ticket": ticket})
 


### PR DESCRIPTION
Hi! 

I am using otp to authenticate, but it fails when `qr_display_thread `is referenced while using otp. This is because `qr_display_thread `is only initialized if you authenticate with qr. After otp is entered it is accessed in line 321 `if qr_display_thread and qr_display_thread.is_alive():`  and fails.

This PR fixes this.

Very nice repo by the way!
